### PR TITLE
Nncleanup: Allows safe DN removal

### DIFF
--- a/client/src/main/java/org/apache/crail/IOCtlResponse.java
+++ b/client/src/main/java/org/apache/crail/IOCtlResponse.java
@@ -11,6 +11,28 @@ abstract public class IOCtlResponse {
     public abstract void update(ByteBuffer buffer) throws IOException;
     public abstract int getSize();
 
+    public static class IOCtlNopResp extends IOCtlResponse {
+        public static int CSIZE = 0;
+
+        public IOCtlNopResp(){
+        }
+
+        public int write(ByteBuffer buffer) throws IOException {
+            return IOCtlNopResp.CSIZE;
+        }
+
+        public void update(ByteBuffer buffer) throws IOException {
+        }
+
+        public int getSize(){
+            return IOCtlNopResp.CSIZE;
+        }
+
+        public String toString(){
+            return "IOCtlNopResp: Empty";
+        }
+    }
+
     public static class IOCtlDataNodeRemoveResp extends IOCtlResponse {
         public static int CSIZE = 0;
 
@@ -36,16 +58,16 @@ abstract public class IOCtlResponse {
     public static class GetClassStatResp extends IOCtlResponse {
         public static int CSIZE = 16;
         private long allBlocks;
-        private long consumedBlocks;
+        private long freeBlocks;
 
         public GetClassStatResp(){
             this.allBlocks = -1;
-            this.consumedBlocks = -1;
+            this.freeBlocks = -1;
         }
 
         public GetClassStatResp(long all, long consumed){
             this.allBlocks = all;
-            this.consumedBlocks = consumed;
+            this.freeBlocks = consumed;
         }
 
         public int write(ByteBuffer buffer) throws IOException {
@@ -54,7 +76,7 @@ abstract public class IOCtlResponse {
             }
             // write 2 longs
             buffer.putLong(this.allBlocks);
-            buffer.putLong(this.consumedBlocks);
+            buffer.putLong(this.freeBlocks);
             return GetClassStatResp.CSIZE;
         }
 
@@ -63,7 +85,7 @@ abstract public class IOCtlResponse {
                 throw new IOException("Read ByteBuffer is too small, remaining " + buffer.remaining() + " expected, " + getSize() + " bytes");
             }
             this.allBlocks = buffer.getLong();
-            this.consumedBlocks = buffer.getLong();
+            this.freeBlocks = buffer.getLong();
         }
 
         public int getSize(){
@@ -71,7 +93,7 @@ abstract public class IOCtlResponse {
         }
 
         public String toString(){
-            return "GetClassStatResp: all block: " + this.allBlocks + " consumed: " + this.consumedBlocks;
+            return "GetClassStatResp: all block: " + this.allBlocks + " free: " + this.freeBlocks;
         }
     }
 }

--- a/client/src/main/java/org/apache/crail/IOCtlResponse.java
+++ b/client/src/main/java/org/apache/crail/IOCtlResponse.java
@@ -1,0 +1,35 @@
+package org.apache.crail;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Created by atr on 11.04.18.
+ */
+abstract public class IOCtlResponse {
+    public abstract int write(ByteBuffer buffer) throws IOException;
+    public abstract void update(ByteBuffer buffer) throws IOException;
+    public abstract int getSize();
+
+    public static class IOCtlEmptyResp extends IOCtlResponse {
+        public static int CSIZE = 0;
+
+        public IOCtlEmptyResp(){
+        }
+
+        public int write(ByteBuffer buffer) throws IOException {
+            return IOCtlEmptyResp.CSIZE;
+        }
+
+        public void update(ByteBuffer buffer) throws IOException {
+        }
+
+        public int getSize(){
+            return IOCtlEmptyResp.CSIZE;
+        }
+
+        public String toString(){
+            return "IOCtlResponse: Empty";
+        }
+    }
+}

--- a/client/src/main/java/org/apache/crail/IOCtlResponse.java
+++ b/client/src/main/java/org/apache/crail/IOCtlResponse.java
@@ -11,25 +11,67 @@ abstract public class IOCtlResponse {
     public abstract void update(ByteBuffer buffer) throws IOException;
     public abstract int getSize();
 
-    public static class IOCtlEmptyResp extends IOCtlResponse {
+    public static class IOCtlDataNodeRemoveResp extends IOCtlResponse {
         public static int CSIZE = 0;
 
-        public IOCtlEmptyResp(){
+        public IOCtlDataNodeRemoveResp(){
         }
 
         public int write(ByteBuffer buffer) throws IOException {
-            return IOCtlEmptyResp.CSIZE;
+            return IOCtlDataNodeRemoveResp.CSIZE;
         }
 
         public void update(ByteBuffer buffer) throws IOException {
         }
 
         public int getSize(){
-            return IOCtlEmptyResp.CSIZE;
+            return IOCtlDataNodeRemoveResp.CSIZE;
         }
 
         public String toString(){
             return "IOCtlResponse: Empty";
+        }
+    }
+
+    public static class GetClassStatResp extends IOCtlResponse {
+        public static int CSIZE = 16;
+        private long allBlocks;
+        private long consumedBlocks;
+
+        public GetClassStatResp(){
+            this.allBlocks = -1;
+            this.consumedBlocks = -1;
+        }
+
+        public GetClassStatResp(long all, long consumed){
+            this.allBlocks = all;
+            this.consumedBlocks = consumed;
+        }
+
+        public int write(ByteBuffer buffer) throws IOException {
+            if(GetClassStatResp.CSIZE > buffer.remaining()) {
+                throw new IOException("Write ByteBuffer is too small, remaining " + buffer.remaining() + " expected, " + GetClassStatResp.CSIZE + " bytes");
+            }
+            // write 2 longs
+            buffer.putLong(this.allBlocks);
+            buffer.putLong(this.consumedBlocks);
+            return GetClassStatResp.CSIZE;
+        }
+
+        public void update(ByteBuffer buffer) throws IOException {
+            if(getSize() > buffer.remaining()) {
+                throw new IOException("Read ByteBuffer is too small, remaining " + buffer.remaining() + " expected, " + getSize() + " bytes");
+            }
+            this.allBlocks = buffer.getLong();
+            this.consumedBlocks = buffer.getLong();
+        }
+
+        public int getSize(){
+            return GetClassStatResp.CSIZE;
+        }
+
+        public String toString(){
+            return "GetClassStatResp: all block: " + this.allBlocks + " consumed: " + this.consumedBlocks;
         }
     }
 }

--- a/client/src/main/java/org/apache/crail/RpcIoctl.java
+++ b/client/src/main/java/org/apache/crail/RpcIoctl.java
@@ -1,0 +1,12 @@
+package org.apache.crail;
+
+/**
+ * Created by atr on 11.04.18.
+ */
+
+import org.apache.crail.rpc.RpcResponse;
+
+public interface RpcIoctl extends RpcResponse {
+    public IOCtlResponse getResponse();
+    public void setResponse(IOCtlResponse resp);
+}

--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -109,8 +109,11 @@ public class CrailConstants {
 	public static String NAMENODE_RPC_SERVICE = "org.apache.crail.namenode.NameNodeService";	
 	
 	public static final String NAMENODE_LOG_KEY = "crail.namenode.log";
-	public static String NAMENODE_LOG = "";		
-	
+	public static String NAMENODE_LOG = "";
+
+	public static final String NAMENODE_REPLAY_REGION_KEY = "crail.namenode.replayregion";
+	public static boolean NAMENODE_REPLAY_REGION = false;
+
 	//storage interface
 	public static final String STORAGE_TYPES_KEY = "crail.storage.types";
 	public static String STORAGE_TYPES = "org.apache.crail.storage.tcp.TcpStorageTier";		
@@ -201,7 +204,10 @@ public class CrailConstants {
 		}
 		if (conf.get(NAMENODE_LOG_KEY) != null) {
 			NAMENODE_LOG = conf.get(NAMENODE_LOG_KEY);
-		}		
+		}
+		if (conf.get(CrailConstants.NAMENODE_REPLAY_REGION_KEY) != null) {
+			NAMENODE_REPLAY_REGION = conf.getBoolean(CrailConstants.NAMENODE_REPLAY_REGION_KEY, false);
+		}
 		
 		//storage interface
 		if (conf.get(STORAGE_TYPES_KEY) != null) {
@@ -246,6 +252,7 @@ public class CrailConstants {
 		LOG.info(NAMENODE_FILEBLOCKS_KEY + " " + NAMENODE_FILEBLOCKS);
 		LOG.info(NAMENODE_RPC_TYPE_KEY + " " + NAMENODE_RPC_TYPE);
 		LOG.info(NAMENODE_LOG_KEY + " " + NAMENODE_LOG);
+		LOG.info(NAMENODE_REPLAY_REGION_KEY + " " + NAMENODE_REPLAY_REGION);
 		LOG.info(STORAGE_TYPES_KEY + " " + STORAGE_TYPES);
 		LOG.info(STORAGE_CLASSES_KEY + " " + STORAGE_CLASSES);
 		LOG.info(STORAGE_ROOTCLASS_KEY + " " + STORAGE_ROOTCLASS);

--- a/client/src/main/java/org/apache/crail/core/CoreDataStore.java
+++ b/client/src/main/java/org/apache/crail/core/CoreDataStore.java
@@ -33,16 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.crail.CrailBlockLocation;
-import org.apache.crail.CrailBuffer;
-import org.apache.crail.CrailStore;
-import org.apache.crail.CrailLocationClass;
-import org.apache.crail.CrailNode;
-import org.apache.crail.CrailNodeType;
-import org.apache.crail.CrailResult;
-import org.apache.crail.CrailStatistics;
-import org.apache.crail.CrailStorageClass;
-import org.apache.crail.Upcoming;
+import org.apache.crail.*;
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.memory.BufferCache;
@@ -468,12 +459,13 @@ public class CoreDataStore extends CrailStore {
 		}		
 	}
 
-	public void ioctlNameNode(IOCtlCommand cmd) throws Exception {
-		RpcVoid voidRes = rpcConnection.ioctlNameNode(cmd).get(CrailConstants.RPC_TIMEOUT,
+	public IOCtlResponse ioctlNameNode(IOCtlCommand cmd) throws Exception {
+		RpcIoctl resp = rpcConnection.ioctlNameNode(cmd).get(CrailConstants.RPC_TIMEOUT,
 				TimeUnit.MILLISECONDS);
-		if (voidRes.getError() != RpcErrors.ERR_OK) {
-			throw new IOException("IOCtl: " + RpcErrors.messages[voidRes.getError()]);
+		if (resp.getError() != RpcErrors.ERR_OK) {
+			throw new IOException("IOCtl: " + RpcErrors.messages[resp.getError()]);
 		}
+		return resp.getResponse();
 	}
 
 	public CrailBuffer allocateBuffer() throws IOException {

--- a/client/src/main/java/org/apache/crail/core/CoreDataStore.java
+++ b/client/src/main/java/org/apache/crail/core/CoreDataStore.java
@@ -50,17 +50,7 @@ import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeInfo;
 import org.apache.crail.metadata.FileInfo;
 import org.apache.crail.metadata.FileName;
-import org.apache.crail.rpc.RpcClient;
-import org.apache.crail.rpc.RpcConnection;
-import org.apache.crail.rpc.RpcCreateFile;
-import org.apache.crail.rpc.RpcDeleteFile;
-import org.apache.crail.rpc.RpcDispatcher;
-import org.apache.crail.rpc.RpcErrors;
-import org.apache.crail.rpc.RpcFuture;
-import org.apache.crail.rpc.RpcGetFile;
-import org.apache.crail.rpc.RpcGetLocation;
-import org.apache.crail.rpc.RpcPing;
-import org.apache.crail.rpc.RpcRenameFile;
+import org.apache.crail.rpc.*;
 import org.apache.crail.storage.StorageClient;
 import org.apache.crail.utils.BlockCache;
 import org.apache.crail.utils.BufferCheckpoint;
@@ -476,6 +466,15 @@ public class CoreDataStore extends CrailStore {
 			LOG.info("Ping: " + RpcErrors.messages[pingRes.getError()]);
 			throw new IOException(RpcErrors.messages[pingRes.getError()]);
 		}		
+	}
+
+	public void ioctlNameNode(IOCtlCommand cmd) throws Exception {
+		RpcVoid voidRes = rpcConnection.ioctlNameNode(cmd).get(CrailConstants.RPC_TIMEOUT,
+				TimeUnit.MILLISECONDS);
+		if (voidRes.getError() != RpcErrors.ERR_OK) {
+			LOG.info("IOCtl: " + RpcErrors.messages[voidRes.getError()]);
+			throw new IOException(RpcErrors.messages[voidRes.getError()]);
+		}
 	}
 
 	public CrailBuffer allocateBuffer() throws IOException {

--- a/client/src/main/java/org/apache/crail/core/CoreDataStore.java
+++ b/client/src/main/java/org/apache/crail/core/CoreDataStore.java
@@ -472,8 +472,7 @@ public class CoreDataStore extends CrailStore {
 		RpcVoid voidRes = rpcConnection.ioctlNameNode(cmd).get(CrailConstants.RPC_TIMEOUT,
 				TimeUnit.MILLISECONDS);
 		if (voidRes.getError() != RpcErrors.ERR_OK) {
-			LOG.info("IOCtl: " + RpcErrors.messages[voidRes.getError()]);
-			throw new IOException(RpcErrors.messages[voidRes.getError()]);
+			throw new IOException("IOCtl: " + RpcErrors.messages[voidRes.getError()]);
 		}
 	}
 

--- a/client/src/main/java/org/apache/crail/metadata/BlockInfo.java
+++ b/client/src/main/java/org/apache/crail/metadata/BlockInfo.java
@@ -29,14 +29,17 @@ public class BlockInfo {
 	protected long lba;
 	protected long addr;
 	protected int length;
-	protected int lkey;	
-	
+	protected int lkey;
+	// BAD: this is namenode specific stuff here.
+	protected boolean deleted;
+
 	public BlockInfo(){
 		this.dnInfo = new DataNodeInfo();
 		this.lba = 0;
 		this.addr = 0;
 		this.length = 0;
 		this.lkey = 0;
+		this.deleted = false;
 	}
 	
 	public BlockInfo(DataNodeInfo dnInfo, long lba, long addr, int length, int lkey){
@@ -45,6 +48,7 @@ public class BlockInfo {
 		this.addr = addr;
 		this.length = length;
 		this.lkey = lkey;
+		this.deleted = false;
 	}
 	
 	public void setBlockInfo(BlockInfo blockInfo) {
@@ -53,7 +57,7 @@ public class BlockInfo {
 		this.addr = blockInfo.getAddr();
 		this.length = blockInfo.getLength();
 		this.lkey = blockInfo.getLkey();
-		
+		this.deleted = blockInfo.deleted;
 	}
 
 	public int write(ByteBuffer buffer){
@@ -71,6 +75,7 @@ public class BlockInfo {
 		this.addr = buffer.getLong();
 		this.length = buffer.getInt();
 		this.lkey = buffer.getInt();
+		// we do not serialize deleted
 	}
 
 	public long getLba() {
@@ -91,6 +96,14 @@ public class BlockInfo {
 
 	public DataNodeInfo getDnInfo() {
 		return dnInfo;
+	}
+
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	public void setDeleted() {
+		this.deleted = true;
 	}
 
 	@Override

--- a/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
+++ b/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
@@ -101,6 +101,10 @@ public abstract class IOCtlCommand {
             this.storageClass = buffer.getInt();
         }
 
+        public int getStorageClass(){
+            return this.storageClass;
+        }
+
         public int getSize(){ return GetClassStatCommand.CSIZE;}
 
         public String toString(){ return "GetClassStatCommand class: " + this.storageClass;}

--- a/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
+++ b/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
@@ -73,6 +73,34 @@ public abstract class IOCtlCommand {
         }
     }
 
+    public static class GetClassStatCommand extends IOCtlCommand {
+        public static int CSIZE = 4;
+        private int storageClass;
+
+        public GetClassStatCommand (int storageClass){
+            this.storageClass = storageClass;
+        }
+
+        public int write(ByteBuffer buffer) throws IOException {
+            if(GetClassStatCommand.CSIZE > buffer.remaining()) {
+                throw new IOException("Write ByteBuffer is too small, remaining " + buffer.remaining() + " expected, " + GetClassStatCommand.CSIZE + " bytes");
+            }
+            buffer.putInt(this.storageClass);
+            return GetClassStatCommand.CSIZE;
+        }
+
+        public void update(ByteBuffer buffer) throws IOException {
+            if(GetClassStatCommand.CSIZE > buffer.remaining()) {
+                throw new IOException("Write ByteBuffer is too small, remaining " + buffer.remaining() + " expected, " + GetClassStatCommand.CSIZE + " bytes");
+            }
+            this.storageClass = buffer.getInt();
+        }
+
+        public int getSize(){ return GetClassStatCommand.CSIZE;}
+
+        public String toString(){ return "GetClassStatCommand class: " + this.storageClass;}
+    }
+
     public static class NoOpCommand extends IOCtlCommand {
 
         NoOpCommand(){}

--- a/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
+++ b/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
@@ -1,0 +1,74 @@
+package org.apache.crail.rpc;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+/**
+ * Created by atr on 04.04.18.
+ */
+public abstract class IOCtlCommand {
+    public static final byte NOP       = 1;
+    public static final byte NN_PING   = 2;
+    public static final byte NN_DUMP   = 3;
+    public static final byte DN_REMOVE = 4;
+
+    public abstract int write(ByteBuffer buffer);
+    public abstract void update(ByteBuffer buffer);
+    public abstract int getSize();
+
+    public static class RemoveDataNode extends IOCtlCommand {
+        // 4 bytes for the IP address of the datanode
+        public static int CSIZE = 4;
+        private InetAddress address;
+
+        RemoveDataNode(){
+            this.address = null;
+        }
+
+        public RemoveDataNode(InetAddress address){
+            this.address = address;
+        }
+
+        public InetAddress getIPAddress(){
+            return this.address;
+        }
+
+        public int write(ByteBuffer buffer) {
+            byte[] x = this.address.getAddress();
+            buffer.put(x);
+            return x.length;
+        }
+
+        public void update(ByteBuffer buffer) {
+            byte[] barr = new byte[4];
+            buffer.get(barr);
+            try {
+                this.address = InetAddress.getByAddress(barr);
+            } catch (UnknownHostException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public int getSize(){
+            return RemoveDataNode.CSIZE;
+        }
+
+        public String toString(){
+            return "removeDN: " + (this.address == null ? " N/A" : this.address.toString());
+        }
+    }
+
+    public static class NoOpCommand extends IOCtlCommand {
+
+        NoOpCommand(){}
+
+        public int write(ByteBuffer buffer){return  0;}
+
+        public void update(ByteBuffer buffer){}
+
+        public int getSize(){ return 0;}
+
+        public String toString(){ return "NoOpCommand";}
+    }
+}

--- a/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
+++ b/client/src/main/java/org/apache/crail/rpc/IOCtlCommand.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 public abstract class IOCtlCommand {
     public static final byte NOP       = 1;
     public static final byte DN_REMOVE = 2;
+    public static final byte NN_GET_CLASS_STAT = 3;
 
     public abstract int write(ByteBuffer buffer) throws IOException;
     public abstract void update(ByteBuffer buffer) throws IOException;
@@ -76,6 +77,10 @@ public abstract class IOCtlCommand {
     public static class GetClassStatCommand extends IOCtlCommand {
         public static int CSIZE = 4;
         private int storageClass;
+
+        public GetClassStatCommand (){
+            this.storageClass = -1;
+        }
 
         public GetClassStatCommand (int storageClass){
             this.storageClass = storageClass;

--- a/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
@@ -60,7 +60,10 @@ public interface RpcConnection {
 
 	public abstract RpcFuture<RpcPing> pingNameNode()
 			throws Exception;
-	
+
+	public abstract RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd)
+			throws IOException;
+
 	public abstract void close() throws Exception;
 	
 	@SuppressWarnings("unchecked")

--- a/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
@@ -22,6 +22,7 @@ package org.apache.crail.rpc;
 import java.io.IOException;
 
 import org.apache.crail.CrailNodeType;
+import org.apache.crail.RpcIoctl;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeInfo;
 import org.apache.crail.metadata.FileInfo;
@@ -61,7 +62,7 @@ public interface RpcConnection {
 	public abstract RpcFuture<RpcPing> pingNameNode()
 			throws Exception;
 
-	public abstract RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd)
+	public abstract RpcFuture<RpcIoctl> ioctlNameNode(IOCtlCommand cmd)
 			throws IOException;
 
 	public abstract void close() throws Exception;

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -136,6 +136,12 @@ public class RpcDispatcher implements RpcConnection {
 	}
 
 	@Override
+	public RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd) throws IOException {
+		System.err.println(" I am here with : " + cmd.getClass().getCanonicalName());
+		throw new IOException();
+	}
+
+	@Override
 	public void close() throws Exception {
 		for (RpcConnection connection : connections){
 			connection.close();

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.crail.CrailNodeType;
+import org.apache.crail.RpcIoctl;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeInfo;
 import org.apache.crail.metadata.FileInfo;
@@ -136,7 +137,7 @@ public class RpcDispatcher implements RpcConnection {
 	}
 
 	@Override
-	public RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd) throws IOException {
+	public RpcFuture<RpcIoctl> ioctlNameNode(IOCtlCommand cmd) throws IOException {
 		throw new IOException();
 	}
 

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -137,7 +137,6 @@ public class RpcDispatcher implements RpcConnection {
 
 	@Override
 	public RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd) throws IOException {
-		System.err.println(" I am here with : " + cmd.getClass().getCanonicalName());
 		throw new IOException();
 	}
 

--- a/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
@@ -56,6 +56,7 @@ public class RpcErrors {
 	public static short ERR_DIR_LOCATION_AFFINITY_MISMATCH = 26;
 	public static short ERR_ADD_BLOCK_FAILED = 27;
 	public static short ERR_CREATE_FILE_BUG = 28;
+	public static short ERR_NO_SUCH_STORAGE_CLASS = 29;
 
 	// more error codes which are used by the datanode side for operations
 	public static short ERR_DN_IOCTL_STOP = -100;
@@ -92,5 +93,6 @@ public class RpcErrors {
 		messages[ERR_DIR_LOCATION_AFFINITY_MISMATCH] = "Directories cannot have local affinity";
 		messages[ERR_ADD_BLOCK_FAILED] = "Could not add block";
 		messages[ERR_CREATE_FILE_BUG] = "Could not retrieve parent block";
+		messages[ERR_NO_SUCH_STORAGE_CLASS] = "Invalid storage class";
 	}
 }

--- a/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
@@ -56,6 +56,11 @@ public class RpcErrors {
 	public static short ERR_DIR_LOCATION_AFFINITY_MISMATCH = 26;
 	public static short ERR_ADD_BLOCK_FAILED = 27;
 	public static short ERR_CREATE_FILE_BUG = 28;
+
+	// more error codes which are used by the datanode side for operations
+	public static short ERR_DN_IOCTL_STOP = -100;
+	public static short ERR_DN_IOCTL_ADD_CORE = -101;
+	public static short ERR_DN_IOCTL_REMOVE_CORE = -102;
 	
 	static {
 		messages[ERR_OK] = "ERROR: No error, all fine";

--- a/client/src/main/java/org/apache/crail/tools/CrailFsck.java
+++ b/client/src/main/java/org/apache/crail/tools/CrailFsck.java
@@ -200,7 +200,8 @@ public class CrailFsck {
 		Option offsetOption = Option.builder("y").desc("offset into the file").hasArg().build();
 		Option lengthOption = Option.builder("l").desc("length of the file [bytes]").hasArg().build();
 		Option storageOption = Option.builder("c").desc("storageClass for file [1..n]").hasArg().build();
-		Option locationOption = Option.builder("p").desc("locationClass for file [1..n]").hasArg().build();		
+		Option locationOption = Option.builder("p").desc("locationClass for file [1..n]").hasArg().build();
+		Option helpOption = Option.builder("h").desc("show help").build();
 		
 		Options options = new Options();
 		options.addOption(dataNodeOption);
@@ -209,7 +210,8 @@ public class CrailFsck {
 		options.addOption(offsetOption);
 		options.addOption(lengthOption);
 		options.addOption(storageOption);
-		options.addOption(locationOption);		
+		options.addOption(locationOption);
+		options.addOption(helpOption);
 		
 		CommandLineParser parser = new DefaultParser();
 		CommandLine line = parser.parse(options, Arrays.copyOfRange(args, 0, args.length));
@@ -221,7 +223,6 @@ public class CrailFsck {
 		}
 		if (line.hasOption(dataNodeOption.getOpt())) {
 			datanodeAddress = InetAddress.getByName(line.getOptionValue(dataNodeOption.getOpt()));
-			System.err.println("Removing datanode: " + datanodeAddress);
 		}
 		if (line.hasOption(offsetOption.getOpt())) {
 			offset = Long.parseLong(line.getOptionValue(offsetOption.getOpt()));
@@ -234,7 +235,12 @@ public class CrailFsck {
 		}
 		if (line.hasOption(locationOption.getOpt())) {
 			locationClass = Integer.parseInt(line.getOptionValue(locationOption.getOpt()));
-		}			
+		}
+		if(line.hasOption(helpOption.getOpt())){
+			HelpFormatter formatter = new HelpFormatter();
+			formatter.printHelp("crail fsck", options);
+			System.exit(0);
+		}
 		
 		CrailFsck fsck = new CrailFsck();
 		if (type.equals("getLocations")){

--- a/client/src/main/java/org/apache/crail/tools/CrailFsck.java
+++ b/client/src/main/java/org/apache/crail/tools/CrailFsck.java
@@ -31,15 +31,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.crail.CrailBlockLocation;
-import org.apache.crail.CrailDirectory;
-import org.apache.crail.CrailStore;
-import org.apache.crail.CrailFile;
-import org.apache.crail.CrailLocationClass;
-import org.apache.crail.CrailMultiFile;
-import org.apache.crail.CrailNode;
-import org.apache.crail.CrailNodeType;
-import org.apache.crail.CrailStorageClass;
+import org.apache.crail.*;
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.core.CoreDataStore;
@@ -147,6 +139,8 @@ public class CrailFsck {
 		CrailConstants.updateConstants(conf);
 		CoreDataStore fs = new CoreDataStore(conf);
 		IOCtlCommand.GetClassStatCommand cmd = new IOCtlCommand.GetClassStatCommand(storageClass);
+		IOCtlResponse.GetClassStatResp stats = (IOCtlResponse.GetClassStatResp) fs.ioctlNameNode(cmd);
+		System.out.println(stats);
 		fs.closeFileSystem();
 	}
 	

--- a/client/src/main/java/org/apache/crail/tools/CrailFsck.java
+++ b/client/src/main/java/org/apache/crail/tools/CrailFsck.java
@@ -141,6 +141,14 @@ public class CrailFsck {
 		System.out.println("Datanode at : " + cmd.getIPAddress() + "/port: " + port + " scheduled for removal successfully");
 		fs.closeFileSystem();
 	}
+
+	public void IOCtlGetClassStats(int storageClass) throws Exception {
+		CrailConfiguration conf = new CrailConfiguration();
+		CrailConstants.updateConstants(conf);
+		CoreDataStore fs = new CoreDataStore(conf);
+		IOCtlCommand.GetClassStatCommand cmd = new IOCtlCommand.GetClassStatCommand(storageClass);
+		fs.closeFileSystem();
+	}
 	
 	public void createDirectory(String filename, int storageClass, int locationClass) throws Exception {
 		System.out.println("createDirectory, filename " + filename + ", storageClass " + storageClass + ", locationClass " + locationClass);
@@ -195,7 +203,7 @@ public class CrailFsck {
 		int storageClass = 0;
 		int locationClass = 0;		
 		
-		Option typeOption = Option.builder("t").desc("type of experiment [getLocations|directoryDump|namenodeDump|blockStatistics|ping|createDirectory|removeDataNode]").hasArg().build();
+		Option typeOption = Option.builder("t").desc("type of experiment [getLocations|directoryDump|namenodeDump|blockStatistics|ping|createDirectory|removeDataNode|getClassStats]").hasArg().build();
 		Option dataNodeOption = Option.builder("d").desc("datanode to be removed").hasArg().build();
 		Option fileOption = Option.builder("f").desc("filename").hasArg().build();
 		Option offsetOption = Option.builder("y").desc("offset into the file").hasArg().build();
@@ -263,6 +271,8 @@ public class CrailFsck {
 			fsck.createDirectory(filename, storageClass, locationClass);
 		} else if (type.equals("removeDataNode")){
 			fsck.IOCtlRemoveDN(datanodeAddress, port);
+		} else if (type.equals("getClassStats")){
+			fsck.IOCtlGetClassStats(storageClass);
 		} else {
 			HelpFormatter formatter = new HelpFormatter();
 			formatter.printHelp("crail fsck", options);

--- a/namenode/src/main/java/org/apache/crail/namenode/AbstractNode.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/AbstractNode.java
@@ -49,7 +49,7 @@ public abstract class AbstractNode extends FileInfo implements Delayed {
 	//get block at the given index, returns a valid block or null otherwise
 	public abstract NameNodeBlockInfo getBlock(int index) throws Exception;
 	//clear all the blocks (used by GC)
-	public abstract void freeBlocks(BlockStore blockStore) throws Exception;	
+	public abstract void freeBlocks(PocketBlockStore blockStore) throws Exception;
 	
 	public AbstractNode(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationAffinity, boolean enumerable){
 		super(fd, type, enumerable);

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -146,6 +146,12 @@ class StorageClass {
 		return RpcErrors.ERR_OK;
 	}
 
+	void removeDatanode(DataNodeInfo dn) throws UnknownHostException {
+		long dnAddress = dn.key();
+		membership.remove(dnAddress);
+		System.err.println("DataNode: " + dn.toString() + " removed from the list");
+	}
+
 	NameNodeBlockInfo getBlock(int affinity) throws InterruptedException {
 		NameNodeBlockInfo block = null;
 		if (affinity == 0) {
@@ -168,13 +174,10 @@ class StorageClass {
 		DataNodeBlocks current = membership.putIfAbsent(dataNode.key(), dataNode);
 		if (current != null) {
 			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
-		} 
-		
+		}
 		// current == null, datanode not in set, adding it now
 		_addDataNode(dataNode);
-		
 		return RpcErrors.ERR_OK;
-
 	}
 	
 	//---------------

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -51,8 +51,12 @@ public class BlockStore {
 	}
 
 	public boolean regionExists(BlockInfo region) {
-		int storageClass = region.getDnInfo().getStorageClass();
-		return storageClasses[storageClass].regionExists(region);
+		if(CrailConstants.NAMENODE_REPLAY_REGION) {
+			int storageClass = region.getDnInfo().getStorageClass();
+			return storageClasses[storageClass].regionExists(region);
+		} else {
+			return false;
+		}
 	}
 
 	public short updateRegion(BlockInfo region) {

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -167,10 +167,11 @@ class StorageClass {
 		DataNodeBlocks old = membership.remove(dnAddress);
 		if(old == null) {
 			System.err.println("DataNode: " + dn.toString() + " not found");
+			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
 		} else {
-			System.err.println("DataNode: " + dn.toString() + " removed from the list");
+			System.err.println("DataNode: " + dn.toString() + " scheduled for removal from the list");
+			return RpcErrors.ERR_OK;
 		}
-		return RpcErrors.ERR_OK;
 	}
 
 	NameNodeBlockInfo getBlock(int affinity) throws InterruptedException {

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -56,11 +56,13 @@ public class DataNodeBlocks extends DataNodeInfo {
 	private void updateMaxCount(){
 		// we want to see what is the maximum block count we have seen with this
 		// node. Eventually that is the capacity we need to get back to.
+		// XXX: this logic does not work if data nodes can de-register capacities
 		if(freeBlocks.size() > this.maxBlockCount)
 			this.maxBlockCount = freeBlocks.size();
 	}
 	
 	public void addFreeBlock(NameNodeBlockInfo nnBlock) {
+		//TODO: checking here the returning value tells us if this is a new or old block.
 		regions.put(nnBlock.getRegion().getLba(), nnBlock.getRegion());
 		freeBlocks.add(nnBlock);
 		updateMaxCount();
@@ -83,8 +85,12 @@ public class DataNodeBlocks extends DataNodeInfo {
 		return  this.maxBlockCount == this.freeBlocks.size();
 	}
 	
-	public int getBlockCount() {
+	public int getFreeBlockCount() {
 		return freeBlocks.size();
+	}
+
+	public long getMaxBlockCount() {
+		return this.maxBlockCount;
 	}
 
 	public boolean regionExists(BlockInfo region) {

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -104,7 +104,11 @@ public class DataNodeBlocks extends DataNodeInfo {
 	public void touch() {
 		this.token = System.nanoTime() + TimeUnit.SECONDS.toNanos(CrailConstants.STORAGE_KEEPALIVE * 8);
 	}
-	
+
+	public boolean isScheduleForRemoval(){
+		return this.scheduleForRemoval;
+	}
+
 	public boolean isOnline(){
 		return (System.nanoTime() <= token) && !this.scheduleForRemoval;
 	}	

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -64,10 +64,7 @@ public class DataNodeBlocks extends DataNodeInfo {
 	}
 
 	public boolean regionExists(BlockInfo region) {
-		if (regions.containsKey(region.getLba())){
-			return true;
-		} 
-		return false;
+		return regions.containsKey(region.getLba());
 	}
 
 	public short updateRegion(BlockInfo region) {

--- a/namenode/src/main/java/org/apache/crail/namenode/DirectoryBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DirectoryBlocks.java
@@ -71,7 +71,7 @@ public class DirectoryBlocks extends AbstractNode {
 	}
 
 	@Override
-	public void freeBlocks(BlockStore blockStore) throws Exception {
+	public void freeBlocks(PocketBlockStore blockStore) throws Exception {
 		Iterator<NameNodeBlockInfo> iter = blocks.values().iterator();
 		while (iter.hasNext()){
 			NameNodeBlockInfo blockInfo = iter.next();

--- a/namenode/src/main/java/org/apache/crail/namenode/FileBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/FileBlocks.java
@@ -74,7 +74,7 @@ public class FileBlocks extends AbstractNode {
 	}
 
 	@Override
-	public void freeBlocks(BlockStore blockStore) throws Exception {
+	public void freeBlocks(PocketBlockStore blockStore) throws Exception {
 		readLock.lock();
 		try {
 			Iterator<NameNodeBlockInfo> iter = blocks.iterator();

--- a/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
@@ -19,9 +19,7 @@
 
 package org.apache.crail.namenode;
 
-import org.apache.crail.rpc.RpcNameNodeService;
-import org.apache.crail.rpc.RpcNameNodeState;
-import org.apache.crail.rpc.RpcProtocol;
+import org.apache.crail.rpc.*;
 import org.apache.crail.rpc.RpcRequestMessage.CreateFileReq;
 import org.apache.crail.rpc.RpcRequestMessage.DumpNameNodeReq;
 import org.apache.crail.rpc.RpcRequestMessage.GetBlockReq;
@@ -42,6 +40,7 @@ import org.apache.crail.rpc.RpcResponseMessage.GetLocationRes;
 import org.apache.crail.rpc.RpcResponseMessage.PingNameNodeRes;
 import org.apache.crail.rpc.RpcResponseMessage.RenameRes;
 import org.apache.crail.rpc.RpcResponseMessage.VoidRes;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class LogDispatcher implements RpcNameNodeService {
 	private RpcNameNodeService service;
@@ -136,5 +135,10 @@ public class LogDispatcher implements RpcNameNodeService {
 			RpcNameNodeState errorState) throws Exception {
 		return service.ping(request, response, errorState);
 	}
-	
+
+	@Override
+	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request, VoidRes response, RpcNameNodeState errorState) throws Exception {
+		throw new NotImplementedException();
+	}
+
 }

--- a/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
@@ -137,7 +137,8 @@ public class LogDispatcher implements RpcNameNodeService {
 	}
 
 	@Override
-	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request, VoidRes response, RpcNameNodeState errorState) throws Exception {
+	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request,
+					   RpcResponseMessage.IOCtlNameNodeRes response, RpcNameNodeState errorState) throws Exception {
 		throw new NotImplementedException();
 	}
 

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeBlockInfo.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeBlockInfo.java
@@ -60,5 +60,4 @@ public class NameNodeBlockInfo extends BlockInfo {
 	public BlockInfo getRegion() {
 		return region;
 	}
-	
 }

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -435,8 +435,8 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		System.err.println(" ### " + region.getDnInfo().toString());
 		
 		short error = RpcErrors.ERR_OK;
-		if (blockStore.regionExists(region)){
-			error = blockStore.updateRegion(region);
+		if (CrailConstants.NAMENODE_REPLAY_REGION){
+			throw new Exception("NYI: update region on the pocket block store.");
 		} else {
 			//rpc
 			int realBlocks = (int) (((long) region.getLength()) / CrailConstants.BLOCK_SIZE) ;
@@ -595,7 +595,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 
 	//--------------- helper functions
 
-	private short prepareDataNodeForRemoval(IOCtlCommand.RemoveDataNode dn){
+	private short prepareDataNodeForRemoval(IOCtlCommand.RemoveDataNode dn) throws Exception {
 		LOG.info("IOCTL: removing data node: " + dn);
 		DataNodeInfo dnInfo = new DataNodeInfo(0, 0, 0, dn.getIPAddress().getAddress(), dn.port());
 		return blockStore.removeDN(dnInfo);

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -45,7 +45,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 	private long serviceId;
 	private long serviceSize;
 	private AtomicLong sequenceId;
-	private BlockStore blockStore;
+	private PocketBlockStore blockStore;
 	private DelayQueue<AbstractNode> deleteQueue;
 	private FileStore fileTree;
 	private ConcurrentHashMap<Long, AbstractNode> fileTable;	
@@ -58,7 +58,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		this.serviceId = Long.parseLong(tokenizer.nextToken().substring(3));
 		this.serviceSize = Long.parseLong(tokenizer.nextToken().substring(5));
 		this.sequenceId = new AtomicLong(serviceId);
-		this.blockStore = new BlockStore();
+		this.blockStore = new PocketBlockStore();
 		this.deleteQueue = new DelayQueue<AbstractNode>();
 		this.fileTree = new FileStore(this);
 		this.fileTable = new ConcurrentHashMap<Long, AbstractNode>();

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -574,8 +574,9 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 	@Override
 	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request, RpcResponseMessage.VoidRes response, RpcNameNodeState errorState) throws Exception {
 		System.err.println("I am here, about to implement ioctl service");
-		switch (request.getOpcode()){
-			case IOCtlCommand.NOP :
+		byte opcode = request.getOpcode();
+		switch (opcode) {
+			case IOCtlCommand.NOP:
 				return RpcErrors.ERR_OK;
 
 			case IOCtlCommand.DN_REMOVE :

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -28,6 +28,7 @@ import java.util.concurrent.DelayQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.crail.CrailNodeType;
+import org.apache.crail.IOCtlResponse;
 import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeInfo;
@@ -596,7 +597,14 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 
 			case IOCtlCommand.DN_REMOVE :
 				IOCtlCommand.RemoveDataNode dn = (IOCtlCommand.RemoveDataNode) request.getIOCtlCommand();
+				IOCtlResponse.IOCtlDataNodeRemoveResp resp = new IOCtlResponse.IOCtlDataNodeRemoveResp();
+				response.setResponse(resp);
 				return prepareDataNodeForRemoval(dn);
+
+			case IOCtlCommand.NN_GET_CLASS_STAT:
+				IOCtlResponse.GetClassStatResp stat = new IOCtlResponse.GetClassStatResp(8, 4);
+				response.setResponse(stat);
+				return RpcErrors.ERR_OK;
 
 			default: throw new NotImplementedException();
 		}

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -584,7 +584,8 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 	}
 
 	@Override
-	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request, RpcResponseMessage.VoidRes response, RpcNameNodeState errorState) throws Exception {
+	public short ioctl(RpcRequestMessage.IoctlNameNodeReq request,
+					   RpcResponseMessage.IOCtlNameNodeRes response, RpcNameNodeState errorState) throws Exception {
 		if (!RpcProtocol.verifyProtocol(RpcProtocol.CMD_IOCTL_NAMENODE, request, response)){
 			return RpcErrors.ERR_PROTOCOL_MISMATCH;
 		}

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -586,7 +586,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 
 			case IOCtlCommand.DN_REMOVE :
 				IOCtlCommand.RemoveDataNode dn = (IOCtlCommand.RemoveDataNode) request.getIOCtlCommand();
-				return prepareDataNodeForRemoval(dn.getIPAddress());
+				return prepareDataNodeForRemoval(dn);
 
 			default: throw new NotImplementedException();
 		}
@@ -595,11 +595,9 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 
 	//--------------- helper functions
 
-	private short prepareDataNodeForRemoval(InetAddress address){
-		System.err.println("Removing data node: " + address);
-		//int storageType, int storageClass, int locationClass, byte[] ipAddress, int port
-		DataNodeInfo dnInfo = new DataNodeInfo(0, 0, 0, address.getAddress(), 50020);
-		// BlockStore is the key entry point
+	private short prepareDataNodeForRemoval(IOCtlCommand.RemoveDataNode dn){
+		LOG.info("IOCTL: removing data node: " + dn);
+		DataNodeInfo dnInfo = new DataNodeInfo(0, 0, 0, dn.getIPAddress().getAddress(), dn.port());
 		return blockStore.removeDN(dnInfo);
 	}
 	

--- a/namenode/src/main/java/org/apache/crail/namenode/PocketBlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/PocketBlockStore.java
@@ -1,0 +1,285 @@
+package org.apache.crail.namenode;
+
+import org.apache.crail.conf.CrailConstants;
+import org.apache.crail.metadata.BlockInfo;
+import org.apache.crail.metadata.DataNodeInfo;
+import org.apache.crail.rpc.RpcErrors;
+import org.apache.crail.utils.AtomicIntegerModulo;
+import org.apache.crail.utils.CrailUtils;
+import org.slf4j.Logger;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Created by atr on 10.04.18.
+ */
+public class PocketBlockStore {
+    private static final Logger LOG = CrailUtils.getLogger();
+
+    private PocketStorageClass[] storageClasses;
+
+    public PocketBlockStore() {
+        storageClasses = new PocketStorageClass[CrailConstants.STORAGE_CLASSES];
+        for (int i = 0; i < CrailConstants.STORAGE_CLASSES; i++) {
+            this.storageClasses[i] = new PocketStorageClass(i);
+        }
+    }
+
+    public short removeDN(DataNodeInfo dn) {
+        int storageClass = dn.getStorageClass();
+        return storageClasses[storageClass].removeDatanode(dn);
+    }
+
+    public short addBlock(NameNodeBlockInfo blockInfo) throws UnknownHostException {
+        int storageClass = blockInfo.getDnInfo().getStorageClass();
+        return storageClasses[storageClass].addBlock(blockInfo);
+    }
+
+    public boolean regionExists(BlockInfo region) {
+        if (CrailConstants.NAMENODE_REPLAY_REGION) {
+            int storageClass = region.getDnInfo().getStorageClass();
+            return storageClasses[storageClass].regionExists(region);
+        } else {
+            return false;
+        }
+    }
+
+    public short updateRegion(BlockInfo region) {
+        int storageClass = region.getDnInfo().getStorageClass();
+        return storageClasses[storageClass].updateRegion(region);
+    }
+
+    private NameNodeBlockInfo _getBlock(int storageClass, int locationAffinity) throws InterruptedException {
+        NameNodeBlockInfo block = null;
+        if (storageClass > 0) {
+            if (storageClass < storageClasses.length) {
+                block = storageClasses[storageClass].getBlock(locationAffinity);
+            } else {
+                //TODO: warn if requested storage class is invalid
+            }
+        }
+        if (block == null) {
+            for (int i = 0; i < storageClasses.length; i++) {
+                block = storageClasses[i].getBlock(locationAffinity);
+                if (block != null) {
+                    break;
+                }
+            }
+        }
+
+        return block;
+    }
+
+    public NameNodeBlockInfo getBlock(int storageClass, int locationAffinity) throws InterruptedException {
+        boolean found = false;
+        NameNodeBlockInfo block = null;
+        while (!found) {
+            block = _getBlock(storageClass, locationAffinity);
+            if (block != null && !block.isDeleted())
+                found = true;
+        }
+        return block;
+    }
+
+    public DataNodeBlocks getDataNode(DataNodeInfo dnInfo) {
+        int storageClass = dnInfo.getStorageClass();
+        return storageClasses[storageClass].getDataNode(dnInfo);
+    }
+}
+
+class PocketStorageClass {
+    private static final Logger LOG = CrailUtils.getLogger();
+    private int storageClass;
+    private ConcurrentHashMap<Long, DataNodeBlocks> membership;
+    private ConcurrentHashMap<Integer, DataNodeArray> affinitySets;
+    private DataNodeArray anySet;
+    private BlockSelection blockSelection;
+
+    public PocketStorageClass(int storageClass) {
+        this.storageClass = storageClass;
+        this.membership = new ConcurrentHashMap<Long, DataNodeBlocks>();
+        this.affinitySets = new ConcurrentHashMap<Integer, DataNodeArray>();
+        if (CrailConstants.NAMENODE_BLOCKSELECTION.equalsIgnoreCase("roundrobin")) {
+            this.blockSelection = new RoundRobinBlockSelection();
+        } else {
+            this.blockSelection = new RandomBlockSelection();
+        }
+        this.anySet = new DataNodeArray(blockSelection);
+    }
+
+    public short updateRegion(BlockInfo region) {
+        long dnAddress = region.getDnInfo().key();
+        DataNodeBlocks current = membership.get(dnAddress);
+        if (current == null) {
+            return RpcErrors.ERR_ADD_BLOCK_FAILED;
+        } else {
+            return current.updateRegion(region);
+        }
+    }
+
+    public boolean regionExists(BlockInfo region) {
+        long dnAddress = region.getDnInfo().key();
+        DataNodeBlocks current = membership.get(dnAddress);
+        if (current == null) {
+            return false;
+        } else {
+            return current.regionExists(region);
+        }
+    }
+
+    short addBlock(NameNodeBlockInfo block) throws UnknownHostException {
+        long dnAddress = block.getDnInfo().key();
+        DataNodeBlocks current = membership.get(dnAddress);
+        if (current == null) {
+            current = DataNodeBlocks.fromDataNodeInfo(block.getDnInfo());
+            addDataNode(current);
+        }
+
+        current.touch();
+        current.addFreeBlock(block);
+        return RpcErrors.ERR_OK;
+    }
+
+    short removeDatanode(DataNodeInfo dn) {
+        long dnAddress = dn.key();
+        DataNodeBlocks old = membership.remove(dnAddress);
+        if (old == null) {
+            System.err.println("DataNode: " + dn.toString() + " not found");
+            return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
+        } else {
+            System.err.println("DataNode: " + dn.toString() + " scheduled for removal from the list");
+            return RpcErrors.ERR_OK;
+        }
+    }
+
+    NameNodeBlockInfo getBlock(int affinity) throws InterruptedException {
+        NameNodeBlockInfo block = null;
+        if (affinity == 0) {
+            block = anySet.get();
+        } else {
+            block = _getAffinityBlock(affinity);
+            if (block == null) {
+                block = anySet.get();
+            } else {
+            }
+        }
+        return block;
+    }
+
+    DataNodeBlocks getDataNode(DataNodeInfo dataNode) {
+        return membership.get(dataNode.key());
+    }
+
+    short addDataNode(DataNodeBlocks dataNode) {
+        DataNodeBlocks current = membership.putIfAbsent(dataNode.key(), dataNode);
+        if (current != null) {
+            return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
+        }
+        // current == null, datanode not in set, adding it now
+        _addDataNode(dataNode);
+        return RpcErrors.ERR_OK;
+    }
+
+    //---------------
+
+    private void _addDataNode(DataNodeBlocks dataNode) {
+        LOG.info("adding datanode " + CrailUtils.getIPAddressFromBytes(dataNode.getIpAddress()) + ":" + dataNode.getPort() + " of type " + dataNode.getStorageType() + " to storage class " + storageClass);
+        DataNodeArray hostMap = affinitySets.get(dataNode.getLocationClass());
+        if (hostMap == null) {
+            hostMap = new DataNodeArray(blockSelection);
+            DataNodeArray oldMap = affinitySets.putIfAbsent(dataNode.getLocationClass(), hostMap);
+            if (oldMap != null) {
+                hostMap = oldMap;
+            }
+        }
+        hostMap.add(dataNode);
+        anySet.add(dataNode);
+    }
+
+    private NameNodeBlockInfo _getAffinityBlock(int affinity) throws InterruptedException {
+        NameNodeBlockInfo block = null;
+        DataNodeArray affinitySet = affinitySets.get(affinity);
+        if (affinitySet != null) {
+            block = affinitySet.get();
+        }
+        return block;
+    }
+
+    public interface BlockSelection {
+        int getNext(int size);
+    }
+
+    private class RoundRobinBlockSelection implements BlockSelection {
+        private AtomicIntegerModulo counter;
+
+        public RoundRobinBlockSelection() {
+            LOG.info("round robin block selection");
+            counter = new AtomicIntegerModulo();
+        }
+
+        @Override
+        public int getNext(int size) {
+            return counter.getAndIncrement() % size;
+        }
+    }
+
+    private class RandomBlockSelection implements BlockSelection {
+        public RandomBlockSelection() {
+            LOG.info("random block selection");
+        }
+
+        @Override
+        public int getNext(int size) {
+            return ThreadLocalRandom.current().nextInt(size);
+        }
+    }
+
+    private class DataNodeArray {
+        private ArrayList<DataNodeBlocks> arrayList;
+        private ReentrantReadWriteLock lock;
+        private BlockSelection blockSelection;
+
+        public DataNodeArray(BlockSelection blockSelection) {
+            this.arrayList = new ArrayList<DataNodeBlocks>();
+            this.lock = new ReentrantReadWriteLock();
+            this.blockSelection = blockSelection;
+        }
+
+        public void add(DataNodeBlocks dataNode) {
+            lock.writeLock().lock();
+            try {
+                arrayList.add(dataNode);
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        private NameNodeBlockInfo get() throws InterruptedException {
+            lock.readLock().lock();
+            try {
+                NameNodeBlockInfo block = null;
+                int size = arrayList.size();
+                if (size > 0) {
+                    int startIndex = blockSelection.getNext(size);
+                    for (int i = 0; i < size; i++) {
+                        int index = (startIndex + i) % size;
+                        DataNodeBlocks anyDn = arrayList.get(index);
+                        if (anyDn.isOnline()) {
+                            block = anyDn.getFreeBlock();
+                        }
+                        if (block != null) {
+                            break;
+                        }
+                    }
+                }
+                return block;
+            } finally {
+                lock.readLock().unlock();
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
      <dependency>
         <groupId>com.ibm.narpc</groupId>
         <artifactId>narpc</artifactId>
-        <version>1.1</version>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
@@ -46,6 +46,7 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 	private RpcRequestMessage.GetDataNodeReq getDataNodeReq;
 	private RpcRequestMessage.DumpNameNodeReq dumpNameNodeReq;
 	private RpcRequestMessage.PingNameNodeReq pingNameNodeReq;
+	private RpcRequestMessage.IoctlNameNodeReq ioctlNameNodeReq;
 
 	public TcpNameNodeRequest() {
 		this.cmd = 0;
@@ -61,6 +62,7 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		this.dumpNameNodeReq = new RpcRequestMessage.DumpNameNodeReq();
 		this.pingNameNodeReq = new RpcRequestMessage.PingNameNodeReq();
 		this.getDataNodeReq = new RpcRequestMessage.GetDataNodeReq();
+		this.ioctlNameNodeReq = new IoctlNameNodeReq();
 	}	
 	
 	public TcpNameNodeRequest(RpcRequestMessage.CreateFileReq message) {
@@ -116,6 +118,11 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		this.type = message.getType();
 		this.pingNameNodeReq = message;
 	}
+
+	public TcpNameNodeRequest(RpcRequestMessage.IoctlNameNodeReq message) {
+		this.type = message.getType();
+		this.ioctlNameNodeReq = message;
+	}
 	
 	public void setCommand(short command) {
 		this.cmd = command;
@@ -164,8 +171,11 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		case RpcProtocol.REQ_PING_NAMENODE:
 			written += pingNameNodeReq.write(buffer);
 			break;
+		case RpcProtocol.REQ_IOCTL_NAMENODE:
+			written += ioctlNameNodeReq.write(buffer);
+			break;
+		default: throw new IOException("Illegal type: " + type);
 		}
-		
 		return written;
 	}
 	
@@ -207,6 +217,10 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		case RpcProtocol.REQ_PING_NAMENODE:
 			pingNameNodeReq.update(buffer);
 			break;
+		case RpcProtocol.REQ_IOCTL_NAMENODE:
+			ioctlNameNodeReq.update(buffer);
+			break;
+		default: throw new IOException("Illegal type: " + type);
 		}
 	}
 
@@ -260,5 +274,9 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 	
 	public RpcRequestMessage.PingNameNodeReq pingNameNode(){
 		return this.pingNameNodeReq;
+	}
+
+	public RpcRequestMessage.IoctlNameNodeReq ioctlNameNode(){
+		return this.ioctlNameNodeReq;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
@@ -19,6 +19,7 @@
 
 package org.apache.crail.namenode.rpc.tcp;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.crail.rpc.RpcNameNodeState;
@@ -44,6 +45,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	private RpcResponseMessage.GetLocationRes getLocationRes;	
 	private RpcResponseMessage.GetDataNodeRes getDataNodeRes;
 	private RpcResponseMessage.PingNameNodeRes pingNameNodeRes;
+	private RpcResponseMessage.IOCtlNameNodeRes ioCtlNameNodeRes;
 
 	public TcpNameNodeResponse() {
 		this.type = 0;
@@ -57,6 +59,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		this.getLocationRes = new RpcResponseMessage.GetLocationRes();
 		this.getDataNodeRes = new RpcResponseMessage.GetDataNodeRes();
 		this.pingNameNodeRes = new RpcResponseMessage.PingNameNodeRes();
+		this.ioCtlNameNodeRes = new RpcResponseMessage.IOCtlNameNodeRes();
 	}
 	
 	public TcpNameNodeResponse(RpcResponseMessage.VoidRes message) {
@@ -103,6 +106,11 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		this.type = message.getType();
 		this.pingNameNodeRes = message;
 	}
+
+	public TcpNameNodeResponse(RpcResponseMessage.IOCtlNameNodeRes message) {
+		this.type = message.getType();
+		this.ioCtlNameNodeRes = message;
+	}
 	
 	public void setType(short type) throws Exception {
 		this.type = type;
@@ -112,7 +120,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		return CSIZE;
 	}
 	
-	public int write(ByteBuffer buffer){
+	public int write(ByteBuffer buffer) throws IOException {
 		buffer.putShort(type);
 		buffer.putShort(error);
 		
@@ -144,13 +152,16 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 			break;			
 		case RpcProtocol.RES_PING_NAMENODE:
 			written += pingNameNodeRes.write(buffer);
-			break;			
+			break;
+		case RpcProtocol.RES_IOCTL_NAMENODE:
+			written += ioCtlNameNodeRes.write(buffer);
+			break;
 		}
 		
 		return written;
 	}
 	
-	public void update(ByteBuffer buffer){
+	public void update(ByteBuffer buffer) throws IOException{
 		this.type = buffer.getShort();
 		this.error = buffer.getShort();
 
@@ -190,7 +201,11 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		case RpcProtocol.RES_PING_NAMENODE:
 			pingNameNodeRes.update(buffer);
 			pingNameNodeRes.setError(error);
-			break;		
+			break;
+		case RpcProtocol.RES_IOCTL_NAMENODE:
+			ioCtlNameNodeRes.update(buffer);
+			ioCtlNameNodeRes.setError(error);
+			break;
 		}
 	}
 	
@@ -240,5 +255,9 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	
 	public RpcResponseMessage.PingNameNodeRes pingNameNode(){
 		return this.pingNameNodeRes;
+	}
+
+	public RpcResponseMessage.IOCtlNameNodeRes ioCtlNameNode(){
+		return this.ioCtlNameNodeRes;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
@@ -44,7 +44,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	private RpcResponseMessage.GetLocationRes getLocationRes;	
 	private RpcResponseMessage.GetDataNodeRes getDataNodeRes;
 	private RpcResponseMessage.PingNameNodeRes pingNameNodeRes;
-	
+
 	public TcpNameNodeResponse() {
 		this.type = 0;
 		this.error = 0;
@@ -153,7 +153,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	public void update(ByteBuffer buffer){
 		this.type = buffer.getShort();
 		this.error = buffer.getShort();
-		
+
 		switch(type){
 		case RpcProtocol.RES_VOID:
 			voidRes.update(buffer);

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -190,7 +190,7 @@ public class TcpRpcConnection implements RpcConnection {
 	@Override
 	public RpcFuture<RpcIoctl> ioctlNameNode(IOCtlCommand cmd) throws IOException {
 		RpcRequestMessage.IoctlNameNodeReq req = new RpcRequestMessage.IoctlNameNodeReq();
-		req.setRemoveDatanode((IOCtlCommand.RemoveDataNode) cmd);
+		req.setIoctlCommand(cmd);
 		RpcResponseMessage.IOCtlNameNodeRes resp = new RpcResponseMessage.IOCtlNameNodeRes();
 
 		TcpNameNodeRequest request = new TcpNameNodeRequest(req);

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -52,6 +52,7 @@ public class TcpRpcConnection implements RpcConnection {
 	}
 
 	public void close() throws IOException {
+		LOG.info("Closing the namenode side client connection: " + this.endpoint.address());
 		this.endpoint.close();
 	}
 

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -23,6 +23,7 @@ import com.ibm.narpc.NaRPCEndpoint;
 import com.ibm.narpc.NaRPCFuture;
 
 import org.apache.crail.CrailNodeType;
+import org.apache.crail.RpcIoctl;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeInfo;
 import org.apache.crail.metadata.FileInfo;
@@ -187,15 +188,15 @@ public class TcpRpcConnection implements RpcConnection {
 	}
 
 	@Override
-	public RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd) throws IOException {
+	public RpcFuture<RpcIoctl> ioctlNameNode(IOCtlCommand cmd) throws IOException {
 		RpcRequestMessage.IoctlNameNodeReq req = new RpcRequestMessage.IoctlNameNodeReq();
 		req.setRemoveDatanode((IOCtlCommand.RemoveDataNode) cmd);
-		RpcResponseMessage.VoidRes resp = new RpcResponseMessage.VoidRes();
+		RpcResponseMessage.IOCtlNameNodeRes resp = new RpcResponseMessage.IOCtlNameNodeRes();
 
 		TcpNameNodeRequest request = new TcpNameNodeRequest(req);
 		TcpNameNodeResponse response = new TcpNameNodeResponse(resp);
 		request.setCommand(RpcProtocol.CMD_IOCTL_NAMENODE);
 		NaRPCFuture<TcpNameNodeRequest, TcpNameNodeResponse> future = endpoint.issueRequest(request, response);
-		return new TcpFuture<RpcVoid>(future, resp);
+		return new TcpFuture<RpcIoctl>(future, resp);
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -185,4 +185,16 @@ public class TcpRpcConnection implements RpcConnection {
 		return new TcpFuture<RpcPing>(future, resp);
 	}
 
+	@Override
+	public RpcFuture<RpcVoid> ioctlNameNode(IOCtlCommand cmd) throws IOException {
+		RpcRequestMessage.IoctlNameNodeReq req = new RpcRequestMessage.IoctlNameNodeReq();
+		req.setRemoveDatanode((IOCtlCommand.RemoveDataNode) cmd);
+		RpcResponseMessage.VoidRes resp = new RpcResponseMessage.VoidRes();
+
+		TcpNameNodeRequest request = new TcpNameNodeRequest(req);
+		TcpNameNodeResponse response = new TcpNameNodeResponse(resp);
+		request.setCommand(RpcProtocol.CMD_IOCTL_NAMENODE);
+		NaRPCFuture<TcpNameNodeRequest, TcpNameNodeResponse> future = endpoint.issueRequest(request, response);
+		return new TcpFuture<RpcVoid>(future, resp);
+	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
@@ -84,9 +84,12 @@ public class TcpRpcDispatcher implements NaRPCService<TcpNameNodeRequest, TcpNam
 			case RpcProtocol.CMD_PING_NAMENODE:
 				error = service.ping(request.pingNameNode(), response.pingNameNode(), response);
 				break;
+			case RpcProtocol.CMD_IOCTL_NAMENODE:
+				error = service.ioctl(request.ioctlNameNode(), response.getVoid(), response);
+				break;
 			default:
 				error = RpcErrors.ERR_INVALID_RPC_CMD;
-				LOG.info("Rpc command not valid, opcode " + request.getCmd());
+				LOG.error("Rpc command not valid, opcode " + request.getCmd());
 			}
 		} catch(Exception e){
 			error = RpcErrors.ERR_UNKNOWN;

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.crail.namenode.rpc.tcp;
 
+import com.ibm.narpc.NaRPCServerChannel;
 import com.ibm.narpc.NaRPCService;
 
 import org.apache.crail.rpc.RpcErrors;
@@ -26,6 +27,8 @@ import org.apache.crail.rpc.RpcNameNodeService;
 import org.apache.crail.rpc.RpcProtocol;
 import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
+
+import java.io.IOException;
 
 public class TcpRpcDispatcher implements NaRPCService<TcpNameNodeRequest, TcpNameNodeResponse> {
 	public static final Logger LOG = CrailUtils.getLogger();
@@ -99,5 +102,23 @@ public class TcpRpcDispatcher implements NaRPCService<TcpNameNodeRequest, TcpNam
 		}
 		
 		return response;		
+	}
+
+	@Override
+	public void addEndpoint(NaRPCServerChannel newConnection) {
+		try {
+			LOG.info("A new connection arrives from : " + newConnection.address());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void removeEndpoint(NaRPCServerChannel closedConnection) {
+		try {
+			LOG.info("Connection closed from : " + closedConnection.address());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
@@ -85,7 +85,7 @@ public class TcpRpcDispatcher implements NaRPCService<TcpNameNodeRequest, TcpNam
 				error = service.ping(request.pingNameNode(), response.pingNameNode(), response);
 				break;
 			case RpcProtocol.CMD_IOCTL_NAMENODE:
-				error = service.ioctl(request.ioctlNameNode(), response.getVoid(), response);
+				error = service.ioctl(request.ioctlNameNode(), response.ioCtlNameNode(), response);
 				break;
 			default:
 				error = RpcErrors.ERR_INVALID_RPC_CMD;

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
@@ -68,7 +68,7 @@ public interface RpcNameNodeService {
 			throws Exception;
 
 	public abstract short ioctl(RpcRequestMessage.IoctlNameNodeReq request,
-							   RpcResponseMessage.VoidRes response, RpcNameNodeState errorState)
+							   RpcResponseMessage.IOCtlNameNodeRes response, RpcNameNodeState errorState)
 			throws Exception;
 	
 	@SuppressWarnings("unchecked")

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
@@ -66,6 +66,10 @@ public interface RpcNameNodeService {
 	public abstract short ping(RpcRequestMessage.PingNameNodeReq request,
 			RpcResponseMessage.PingNameNodeRes response, RpcNameNodeState errorState)
 			throws Exception;
+
+	public abstract short ioctl(RpcRequestMessage.IoctlNameNodeReq request,
+							   RpcResponseMessage.VoidRes response, RpcNameNodeState errorState)
+			throws Exception;
 	
 	@SuppressWarnings("unchecked")
 	public static RpcNameNodeService createInstance(String name) throws Exception {

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
@@ -19,7 +19,6 @@
 
 package org.apache.crail.rpc;
 
-import org.apache.crail.rpc.RpcErrors;
 import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
@@ -41,6 +40,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short CMD_DUMP_NAMENODE = 10;
 	public static final short CMD_PING_NAMENODE = 11;
 	public static final short CMD_GET_DATANODE = 12;
+	public static final short CMD_IOCTL_NAMENODE = 13;
 	
 	//request types
 	public static final short REQ_CREATE_FILE = 1;	
@@ -54,6 +54,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short REQ_DUMP_NAMENODE = 10;
 	public static final short REQ_PING_NAMENODE = 11;
 	public static final short REQ_GET_DATANODE = 12;
+	public static final short REQ_IOCTL_NAMENODE = 13;
 	
 	//response types
 	public static final short RES_VOID = 1;
@@ -65,8 +66,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short RES_GET_LOCATION = 7;
 	public static final short RES_PING_NAMENODE = 9;
 	public static final short RES_GET_DATANODE = 10;
-	
-	
+
 	static {
 		requestTypes[0] = 0;
 		requestTypes[CMD_CREATE_FILE] = REQ_CREATE_FILE;
@@ -80,6 +80,7 @@ public class RpcProtocol extends RpcErrors {
 		requestTypes[CMD_DUMP_NAMENODE] = REQ_DUMP_NAMENODE;
 		requestTypes[CMD_PING_NAMENODE] = REQ_PING_NAMENODE;	
 		requestTypes[CMD_GET_DATANODE] = REQ_GET_DATANODE;
+		requestTypes[CMD_IOCTL_NAMENODE] = REQ_IOCTL_NAMENODE;
 		
 		responseTypes[0] = 0;
 		responseTypes[CMD_CREATE_FILE] = RES_CREATE_FILE;
@@ -93,6 +94,8 @@ public class RpcProtocol extends RpcErrors {
 		responseTypes[CMD_DUMP_NAMENODE] = RES_VOID;
 		responseTypes[CMD_PING_NAMENODE] = RES_PING_NAMENODE;	
 		responseTypes[CMD_GET_DATANODE] = RES_GET_DATANODE;
+		// as a response of an ioctl call, we just expect an error code
+		responseTypes[CMD_IOCTL_NAMENODE] = RES_VOID;
 	}
 	
 

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
@@ -66,6 +66,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short RES_GET_LOCATION = 7;
 	public static final short RES_PING_NAMENODE = 9;
 	public static final short RES_GET_DATANODE = 10;
+	public static final short RES_IOCTL_NAMENODE = 11;
 
 	static {
 		requestTypes[0] = 0;
@@ -94,8 +95,7 @@ public class RpcProtocol extends RpcErrors {
 		responseTypes[CMD_DUMP_NAMENODE] = RES_VOID;
 		responseTypes[CMD_PING_NAMENODE] = RES_PING_NAMENODE;	
 		responseTypes[CMD_GET_DATANODE] = RES_GET_DATANODE;
-		// as a response of an ioctl call, we just expect an error code
-		responseTypes[CMD_IOCTL_NAMENODE] = RES_VOID;
+		responseTypes[CMD_IOCTL_NAMENODE] = RES_IOCTL_NAMENODE;
 	}
 	
 

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
@@ -584,9 +584,13 @@ public class RpcRequestMessage {
 			this.cmd = new IOCtlCommand.NoOpCommand();
 		}
 
-		public void setRemoveDatanode(IOCtlCommand.RemoveDataNode ops) {
-			this.opcode = IOCtlCommand.DN_REMOVE;
+		public void setIoctlCommand(IOCtlCommand ops){
 			this.cmd = ops;
+			if (ops instanceof IOCtlCommand.RemoveDataNode) {
+				this.opcode = IOCtlCommand.DN_REMOVE;
+			} else if (ops instanceof IOCtlCommand.GetClassStatCommand) {
+				this.opcode = IOCtlCommand.NN_GET_CLASS_STAT;
+			}
 		}
 
 		public byte getOpcode() {
@@ -629,6 +633,9 @@ public class RpcRequestMessage {
 					break;
 				case IOCtlCommand.NOP:
 					this.cmd = new IOCtlCommand.NoOpCommand();
+					break;
+				case IOCtlCommand.NN_GET_CLASS_STAT:
+					this.cmd = new IOCtlCommand.GetClassStatCommand();
 					break;
 				default:
 					throw new IOException("NYI: ioctl opcode " + this.opcode);

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -694,6 +694,9 @@ public class RpcResponseMessage {
 			this.opcode = buffer.get();
 			/* which type ? */
 			switch (this.opcode) {
+				case IOCtlCommand.NOP:
+					this.resp = new IOCtlResponse.IOCtlNopResp();
+					break;
 				case IOCtlCommand.DN_REMOVE:
 					this.resp = new IOCtlResponse.IOCtlDataNodeRemoveResp();
 					break;

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -654,7 +654,7 @@ public class RpcResponseMessage {
 		private short error;
 
 		public IOCtlNameNodeRes() {
-			this.resp = new IOCtlResponse.IOCtlEmptyResp();
+			this.resp = new IOCtlResponse.IOCtlDataNodeRemoveResp();
 			this.opcode = IOCtlCommand.NOP;
 			this.error = -1;
 		}
@@ -695,10 +695,10 @@ public class RpcResponseMessage {
 			/* which type ? */
 			switch (this.opcode) {
 				case IOCtlCommand.DN_REMOVE:
-					this.resp = new IOCtlResponse.IOCtlEmptyResp();
+					this.resp = new IOCtlResponse.IOCtlDataNodeRemoveResp();
 					break;
-				case IOCtlCommand.NOP:
-					this.resp = new IOCtlResponse.IOCtlEmptyResp();
+				case IOCtlCommand.NN_GET_CLASS_STAT:
+					this.resp = new IOCtlResponse.GetClassStatResp();
 					break;
 				default:
 					throw new IOException("NYI: ioctl opcode " + this.opcode);
@@ -713,6 +713,11 @@ public class RpcResponseMessage {
 
 		public void setResponse(IOCtlResponse resp){
 			this.resp = resp;
+			if(resp instanceof IOCtlResponse.GetClassStatResp){
+				this.opcode = IOCtlCommand.NN_GET_CLASS_STAT;
+			} else if(resp instanceof IOCtlResponse.IOCtlDataNodeRemoveResp){
+				this.opcode = IOCtlCommand.DN_REMOVE;
+			}
 		}
 
 		public short getError(){

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -26,22 +26,13 @@ import java.nio.ByteBuffer;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.metadata.DataNodeStatistics;
 import org.apache.crail.metadata.FileInfo;
-import org.apache.crail.rpc.RpcCreateFile;
-import org.apache.crail.rpc.RpcDeleteFile;
-import org.apache.crail.rpc.RpcGetBlock;
-import org.apache.crail.rpc.RpcGetDataNode;
-import org.apache.crail.rpc.RpcGetFile;
-import org.apache.crail.rpc.RpcGetLocation;
-import org.apache.crail.rpc.RpcPing;
-import org.apache.crail.rpc.RpcRenameFile;
-import org.apache.crail.rpc.RpcVoid;
 
 public class RpcResponseMessage {
 	public static class VoidRes implements RpcProtocol.NameNodeRpcMessage, RpcVoid {
 		private short error;
 		
 		public VoidRes() {
-			this.error = 0;
+			this.error = -1;
 		}
 		
 		public int size() {

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -551,15 +551,16 @@ public class RpcResponseMessage {
 	
 	public static class GetDataNodeRes implements RpcProtocol.NameNodeRpcMessage, RpcGetDataNode {
 		public static int CSIZE = DataNodeStatistics.CSIZE;
-		
+		private short error;
 		private DataNodeStatistics statistics;
 
 		public GetDataNodeRes() {
 			this.statistics = new DataNodeStatistics();
+			this.error = -1;
 		}
 		
 		public void setError(short error) {
-			
+			this.error = error;
 		}
 
 		public int size() {
@@ -592,7 +593,7 @@ public class RpcResponseMessage {
 		}
 		
 		public short getError(){
-			return 0;
+			return this.error;
 		}
 
 		public void setServiceId(long serviceId) {

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -151,7 +151,17 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 			return new TcpStorageResponse(TcpStorageProtocol.RET_RPC_UNKNOWN);
 		}
 	}
-	
+
+	@Override
+	public void addEndpoint(NaRPCServerChannel newConnection) {
+		// nothing to do here for now
+	}
+
+	@Override
+	public void removeEndpoint(NaRPCServerChannel closedConnection) {
+		// nothing to do here for now
+	}
+
 	private void clean(){
 		File dataDir = new File(dataDirPath);
 		if (!dataDir.exists()){

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -183,8 +183,14 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
 		InetAddress addr = null;
 		for (InterfaceAddress address: addresses){
-			if (address.getBroadcast() != null){
-				InetAddress _addr = address.getAddress();
+			// only ipv4 address have broadcast address, hence this is a crude way to filter
+			// in ipv4 addresses. But loopback also does not have a broadcast address.
+			// hence we make an OR filter
+			boolean isIpv4Address = (address.getBroadcast() != null);
+			InetAddress _addr = address.getAddress();
+			boolean isLoopbackAddress = _addr.isLoopbackAddress();
+			if (isIpv4Address || isLoopbackAddress){
+				//TODO: what to do with interface with multiple IP addresses?
 				addr = _addr;
 			}
 		}		

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -108,17 +108,30 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 	}
 
 	@Override
+	public void prepareToShutDown(){
+		this.alive = false;
+		// do more clean up, if required
+		try {
+			serverEndpoint.close();
+			serverGroup.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
 	public void run() {
 		try {
 			LOG.info("running TCP storage server, address " + address);
 			this.alive = true;
-			while(true){
+			while(this.alive){
 				NaRPCServerChannel endpoint = serverEndpoint.accept();
 				LOG.info("new connection " + endpoint.address());
 			}
 		} catch(Exception e){
 			e.printStackTrace();
 		}
+		LOG.info("Shutting down the datanode at address " + address);
 	}
 
 	@Override

--- a/storage/src/main/java/org/apache/crail/storage/StorageServer.java
+++ b/storage/src/main/java/org/apache/crail/storage/StorageServer.java
@@ -168,7 +168,7 @@ public interface StorageServer extends Configurable, Runnable {
 				long diffCount = newCount - oldCount;
 				blockCount.put(serviceId, newCount);
 				sumCount += diffCount;
-				LOG.info("datanode statistics, freeBlocks " + sumCount);		
+				LOG.info("datanode1 statistics, freeBlocks " + sumCount);
 			}
 		}
 		
@@ -185,7 +185,7 @@ public interface StorageServer extends Configurable, Runnable {
 			blockCount.put(serviceId, newCount);
 			sumCount += diffCount;			
 			
-			LOG.info("datanode statistics, freeBlocks " + sumCount);
+			LOG.info("datanode2 statistics, freeBlocks " + sumCount);
 			Thread.sleep(CrailConstants.STORAGE_KEEPALIVE*1000);
 		}			
 	}


### PR DESCRIPTION
This patch allows safe datanode removal. A safe removal is when there are no block consumed from the datanode and it is scheduled/marked for removal. 

TODO: unsafe removal needs more work. Working on it. 

NOTE: this requires 1.2 NaRPC from the pocketDev branch of NaRPC.